### PR TITLE
Fix/JPA nullable, toString

### DIFF
--- a/src/main/java/com/bevelop/devbevelop/domain/model/ProjectTemplate.java
+++ b/src/main/java/com/bevelop/devbevelop/domain/model/ProjectTemplate.java
@@ -1,9 +1,7 @@
 package com.bevelop.devbevelop.domain.model;
 
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
-import lombok.ToString;
+import com.sun.istack.NotNull;
+import lombok.*;
 
 import javax.persistence.Column;
 import javax.persistence.Embeddable;
@@ -11,22 +9,28 @@ import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
 
 @Embeddable
-@NoArgsConstructor
-@Getter @Setter @ToString
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@ToString
 public class ProjectTemplate {
+
     @Enumerated(EnumType.STRING)
-    @Column(name = "team_division", nullable = false)
+    @Column(name = "team_division")
+    @NotNull
     private Division division;
 
     //by month?
-    @Column(name = "team_period", nullable = false)
+    @Column(name = "team_period")
+    @NotNull
     private int period;
 
     @Enumerated(EnumType.STRING)
-    @Column(name = "team_task", nullable = false)
+    @Column(name = "team_task")
+    @NotNull
     private Task task;
 
     @Enumerated(EnumType.STRING)
-    @Column (name = "team_category", nullable = false)
+    @Column (name = "team_category")
+    @NotNull
     private Category category;
 }

--- a/src/main/java/com/bevelop/devbevelop/domain/project/domain/Project.java
+++ b/src/main/java/com/bevelop/devbevelop/domain/project/domain/Project.java
@@ -3,15 +3,16 @@ package com.bevelop.devbevelop.domain.project.domain;
 import com.bevelop.devbevelop.domain.model.ProjectTemplate;
 import com.bevelop.devbevelop.domain.team.domain.Team;
 import com.bevelop.devbevelop.domain.user.domain.User;
-import lombok.Getter;
-import lombok.Setter;
-import lombok.ToString;
+import com.sun.istack.NotNull;
+import lombok.*;
 
 import javax.persistence.*;
 
 @Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@ToString
 @Table(name = "project")
-@Setter @Getter @ToString
 public class Project {
 
     @Id
@@ -28,10 +29,12 @@ public class Project {
     private Team team;
 
     @Embedded
-    @Column(name = "projecttmp", nullable = false)
+    @Column(name = "projecttmp")
+    @NotNull
     private ProjectTemplate projecttmp;
 
-    @Column(name = "project_title", nullable = false)
+    @Column(name = "project_title")
+    @NotNull
     private String title;
 
     @Lob

--- a/src/main/java/com/bevelop/devbevelop/domain/stack/Stack.java
+++ b/src/main/java/com/bevelop/devbevelop/domain/stack/Stack.java
@@ -1,15 +1,16 @@
 package com.bevelop.devbevelop.domain.stack;
 
 import com.bevelop.devbevelop.domain.user.domain.User;
+import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
 
 @Getter
-@Table(name = "stacks")
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
+@Table(name = "stacks")
 public class Stack {
 
     @Id

--- a/src/main/java/com/bevelop/devbevelop/domain/team/domain/Team.java
+++ b/src/main/java/com/bevelop/devbevelop/domain/team/domain/Team.java
@@ -1,18 +1,16 @@
 package com.bevelop.devbevelop.domain.team.domain;
 
-import com.bevelop.devbevelop.domain.model.Category;
-import com.bevelop.devbevelop.domain.model.Division;
 import com.bevelop.devbevelop.domain.model.ProjectTemplate;
-import com.bevelop.devbevelop.domain.model.Task;
-import lombok.Getter;
-import lombok.Setter;
-import lombok.ToString;
+import com.sun.istack.NotNull;
+import lombok.*;
 
 import javax.persistence.*;
 
 @Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@ToString
 @Table(name = "team")
-@Getter @Setter @ToString
 public class Team {
 
     @Id
@@ -20,14 +18,17 @@ public class Team {
     @GeneratedValue(strategy = GenerationType.AUTO)
     private Long id;
 
-    @Column(name = "team_title", nullable = false, length = 50)
+    @Column(name = "team_title",length = 50)
+    @NotNull
     private String title;
 
     @Lob
-    @Column(name = "team_detail", nullable = false)
+    @Column(name = "team_detail")
+    @NotNull
     private String detail;
 
     @Embedded
-    @Column(name = "projecttmp", nullable = false)
+    @Column(name = "projecttmp")
+    @NotNull
     private ProjectTemplate projecttmp;
 }

--- a/src/main/java/com/bevelop/devbevelop/domain/team/domain/TeamLike.java
+++ b/src/main/java/com/bevelop/devbevelop/domain/team/domain/TeamLike.java
@@ -2,16 +2,13 @@ package com.bevelop.devbevelop.domain.team.domain;
 
 import com.bevelop.devbevelop.common.entity.BaseEntity;
 import com.bevelop.devbevelop.domain.user.domain.User;
-import lombok.AccessLevel;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import javax.persistence.*;
-
+@Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Entity
+
 public class TeamLike extends BaseEntity {
 
     @Id

--- a/src/main/java/com/bevelop/devbevelop/domain/user/domain/User.java
+++ b/src/main/java/com/bevelop/devbevelop/domain/user/domain/User.java
@@ -2,10 +2,8 @@ package com.bevelop.devbevelop.domain.user.domain;
 
 import com.bevelop.devbevelop.common.entity.BaseEntity;
 import com.bevelop.devbevelop.domain.stack.Stack;
-import lombok.AccessLevel;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import com.sun.istack.NotNull;
+import lombok.*;
 
 import javax.persistence.*;
 import java.util.ArrayList;
@@ -14,6 +12,7 @@ import java.util.List;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
+@ToString
 @Table(name = "bevelop_user")
 public class User extends BaseEntity {
 
@@ -22,13 +21,16 @@ public class User extends BaseEntity {
     @Column(name="user_id")
     private Long id;
 
-    @Column(nullable = false)
+    @Column
+    @NotNull
     private String email;
 
-    @Column(nullable = false)
+    @Column
+    @NotNull
     private String password;
 
-    @Column(nullable = false)
+    @Column
+    @NotNull
     private String name;
 
     @Enumerated(EnumType.STRING)
@@ -47,18 +49,6 @@ public class User extends BaseEntity {
         this.name = name;
         this.job = job;
         this.interests = interests;
-    }
-
-    @Override
-    public String toString() {
-        return "User{" +
-                "id=" + id +
-                ", email='" + email + '\'' +
-                ", password='" + password + '\'' +
-                ", name='" + name + '\'' +
-                ", job=" + job + '\'' +
-                ", interests=" + interests + '\'' +
-                '}';
     }
 
 }

--- a/src/main/java/com/bevelop/devbevelop/domain/user/domain/UserRegister.java
+++ b/src/main/java/com/bevelop/devbevelop/domain/user/domain/UserRegister.java
@@ -1,16 +1,14 @@
 package com.bevelop.devbevelop.domain.user.domain;
 
 import com.bevelop.devbevelop.common.entity.BaseEntity;
-import lombok.AccessLevel;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import javax.persistence.*;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
+@ToString
 public class UserRegister extends BaseEntity {
 
     @Id
@@ -34,16 +32,5 @@ public class UserRegister extends BaseEntity {
         this.status = status;
         this.role = role;
     }
-
-    @Override
-    public String toString() {
-        return "UserRegister{" +
-                "user=" + user +
-                ", status='" + status + '\'' +
-                ", role='" + role + '\'' +
-                '}';
-    }
-
-
 
 }


### PR DESCRIPTION
nullable = false -> @NotNull
데이터베이스에 SQL 쿼리를 보내기 전에 예외가 발생. 좀 더 안정적
toString으로 변경하고 오버라이딩 삭제(하지만 양방향 관계시 참조 무한이 걸릴 수 있으므로 나중에 문제가 생기면 exclude으로 예외처리 필요)
accessLevel.PROTECTED -> 무분별한 객체 생성에 대해 체크 가능. 엔티티 외부 접근.